### PR TITLE
fix(api): guard optional chat history

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -441,7 +441,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const contents: GeminiMessage[] = [
-    ...validation.value.history,
+    ...(validation.value.history ?? []),
     { parts: [{ text: validation.value.message }], role: 'user' },
   ];
 


### PR DESCRIPTION
## Summary
- guard alidation.value.history with ?? [] before spreading
- avoids possible runtime crash when history is omitted
- removes Vercel TypeScript warning in pi/chat.ts

## Validation
- npm run test:api
- npm run build