### PR TITLE
ios-native: VinctusNative Semana 4 scaffold

### DIFF
--- a/ios-native/.gitignore
+++ b/ios-native/.gitignore
@@ -1,0 +1,14 @@
+DerivedData
+.derivedData
+.build
+.swiftpm
+xcuserdata
+*.xcuserstate
+*.xccheckout
+*.moved-aside
+*.xcscmblueprint
+*.xcresult
+.DS_Store
+
+# Firebase config (iOS)
+GoogleService-Info*.plist

--- a/ios-native/VinctusNative/README.md
+++ b/ios-native/VinctusNative/README.md
@@ -1,0 +1,26 @@
+# VinctusNative (iOS)
+
+SwiftUI base app for the native iOS migration (Semana 4+).
+
+## Generate project
+
+This folder uses XcodeGen to generate the Xcode project:
+
+```bash
+cd ios-native/VinctusNative
+xcodegen generate
+```
+
+## Firebase setup (dev/staging/prod)
+
+Add the corresponding Firebase iOS config plists (not committed):
+
+- `ios-native/VinctusNative/Resources/GoogleService-Info-Dev.plist`
+- `ios-native/VinctusNative/Resources/GoogleService-Info-Staging.plist`
+- `ios-native/VinctusNative/Resources/GoogleService-Info-Prod.plist`
+
+The active environment is controlled by the Xcode scheme:
+
+- `VinctusNative-Dev`
+- `VinctusNative-Staging`
+- `VinctusNative-Prod`

--- a/ios-native/VinctusNative/Resources/Info.plist
+++ b/ios-native/VinctusNative/Resources/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>$(DEVELOPMENT_LANGUAGE)</string>
+  <key>CFBundleDisplayName</key>
+  <string>VinctusNative</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(MARKETING_VERSION)</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>UILaunchScreen</key>
+  <dict/>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+  </array>
+  <key>VINCTUS_ENV</key>
+  <string>$(VINCTUS_ENV)</string>
+</dict>
+</plist>
+

--- a/ios-native/VinctusNative/Sources/AppEnvironment.swift
+++ b/ios-native/VinctusNative/Sources/AppEnvironment.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum AppEnvironment: String {
+  case dev
+  case staging
+  case prod
+
+  static var current: AppEnvironment {
+    let raw = Bundle.main.object(forInfoDictionaryKey: "VINCTUS_ENV") as? String
+    return AppEnvironment(rawValue: raw ?? "") ?? .dev
+  }
+
+  var firebasePlistBaseName: String {
+    switch self {
+    case .dev:
+      return "GoogleService-Info-Dev"
+    case .staging:
+      return "GoogleService-Info-Staging"
+    case .prod:
+      return "GoogleService-Info-Prod"
+    }
+  }
+}
+

--- a/ios-native/VinctusNative/Sources/AuthRepo.swift
+++ b/ios-native/VinctusNative/Sources/AuthRepo.swift
@@ -1,0 +1,21 @@
+import FirebaseAuth
+import Foundation
+
+protocol AuthRepo {
+  var currentUser: FirebaseAuth.User? { get }
+  func signInAnonymously() async throws
+  func signOut() throws
+}
+
+final class FirebaseAuthRepo: AuthRepo {
+  var currentUser: FirebaseAuth.User? { Auth.auth().currentUser }
+
+  func signInAnonymously() async throws {
+    _ = try await Auth.auth().signInAnonymously()
+  }
+
+  func signOut() throws {
+    try Auth.auth().signOut()
+  }
+}
+

--- a/ios-native/VinctusNative/Sources/AuthViewModel.swift
+++ b/ios-native/VinctusNative/Sources/AuthViewModel.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@MainActor
+final class AuthViewModel: ObservableObject {
+  @Published private(set) var isSignedIn = false
+  @Published var errorMessage: String?
+
+  private let repo: AuthRepo
+
+  init(repo: AuthRepo) {
+    self.repo = repo
+    self.isSignedIn = repo.currentUser != nil
+  }
+
+  func signInAnonymously() {
+    errorMessage = nil
+    Task {
+      do {
+        try await repo.signInAnonymously()
+        isSignedIn = true
+      } catch {
+        errorMessage = error.localizedDescription
+      }
+    }
+  }
+
+  func signOut() {
+    errorMessage = nil
+    do {
+      try repo.signOut()
+      isSignedIn = false
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+}
+

--- a/ios-native/VinctusNative/Sources/FeedRepo.swift
+++ b/ios-native/VinctusNative/Sources/FeedRepo.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct FeedItem: Identifiable, Hashable {
+  let id: String
+  let title: String
+}
+
+protocol FeedRepo {
+  func fetchFeed(limit: Int) async throws -> [FeedItem]
+}
+
+// Skeleton repo (Semana 4 deliverable). Wire to Firestore contracts in Semana 10+.
+final class FirebaseFeedRepo: FeedRepo {
+  func fetchFeed(limit: Int) async throws -> [FeedItem] {
+    // TODO: implement Firestore read path (feed) once contracts are finalized.
+    return []
+  }
+}
+

--- a/ios-native/VinctusNative/Sources/FeedView.swift
+++ b/ios-native/VinctusNative/Sources/FeedView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct FeedView: View {
+  @StateObject private var vm: FeedViewModel
+
+  init(repo: FeedRepo) {
+    _vm = StateObject(wrappedValue: FeedViewModel(repo: repo))
+  }
+
+  var body: some View {
+    List {
+      if vm.isLoading {
+        Text("Loading…")
+      }
+
+      if let error = vm.errorMessage {
+        Text(error).foregroundStyle(.red)
+      }
+
+      ForEach(vm.items) { item in
+        Text(item.title)
+      }
+
+      if vm.items.isEmpty && !vm.isLoading && vm.errorMessage == nil {
+        Text("Empty feed (skeleton)")
+          .foregroundStyle(.secondary)
+      }
+    }
+    .navigationTitle("Feed")
+    .task { vm.refresh() }
+    .refreshable { vm.refresh() }
+  }
+}
+

--- a/ios-native/VinctusNative/Sources/FeedViewModel.swift
+++ b/ios-native/VinctusNative/Sources/FeedViewModel.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+@MainActor
+final class FeedViewModel: ObservableObject {
+  @Published private(set) var items: [FeedItem] = []
+  @Published var errorMessage: String?
+  @Published private(set) var isLoading = false
+
+  private let repo: FeedRepo
+
+  init(repo: FeedRepo) {
+    self.repo = repo
+  }
+
+  func refresh() {
+    errorMessage = nil
+    isLoading = true
+    Task {
+      do {
+        let fetched = try await repo.fetchFeed(limit: 20)
+        items = fetched
+      } catch {
+        errorMessage = error.localizedDescription
+      }
+      isLoading = false
+    }
+  }
+}
+

--- a/ios-native/VinctusNative/Sources/FirebaseBootstrap.swift
+++ b/ios-native/VinctusNative/Sources/FirebaseBootstrap.swift
@@ -1,0 +1,38 @@
+import Foundation
+import FirebaseCore
+
+enum FirebaseBootstrap {
+  static func configureIfPossible() {
+    guard FirebaseApp.app() == nil else { return }
+
+    // Prefer env-scoped plist.
+    let env = AppEnvironment.current
+    if let options = optionsFromPlist(named: env.firebasePlistBaseName) {
+      FirebaseApp.configure(options: options)
+      return
+    }
+
+    // Fallback: allow dropping a default GoogleService-Info.plist into Resources.
+    if let options = optionsFromPlist(named: "GoogleService-Info") {
+      FirebaseApp.configure(options: options)
+      return
+    }
+
+    // No plist present: keep app runnable, but disable Firebase features.
+    NSLog("Firebase not configured (missing GoogleService-Info plist). Env=%{public}@", env.rawValue)
+  }
+
+  private static func optionsFromPlist(named baseName: String) -> FirebaseOptions? {
+    guard let path = Bundle.main.path(forResource: baseName, ofType: "plist") else { return nil }
+    guard let options = FirebaseOptions(contentsOfFile: path) else { return nil }
+
+    // Avoid configuring Firebase with placeholder values.
+    let markers = ["REPLACE_ME", "your_", "YOUR_"]
+    let values = [options.apiKey, options.googleAppID, options.projectID]
+    let isPlaceholder = values
+      .compactMap { $0 }
+      .contains { v in markers.contains(where: { v.localizedCaseInsensitiveContains($0) }) }
+    return isPlaceholder ? nil : options
+  }
+}
+

--- a/ios-native/VinctusNative/Sources/RootView.swift
+++ b/ios-native/VinctusNative/Sources/RootView.swift
@@ -1,0 +1,42 @@
+import FirebaseCore
+import SwiftUI
+
+struct RootView: View {
+  @StateObject private var authVM = AuthViewModel(repo: FirebaseAuthRepo())
+
+  var body: some View {
+    NavigationStack {
+      VStack(alignment: .leading, spacing: 12) {
+        Text("VinctusNative")
+          .font(.title)
+          .bold()
+
+        Text("Env: \(AppEnvironment.current.rawValue)")
+          .foregroundStyle(.secondary)
+
+        Text(FirebaseApp.app() == nil ? "Firebase: NOT configured" : "Firebase: configured")
+          .foregroundStyle(FirebaseApp.app() == nil ? .orange : .green)
+
+        if let error = authVM.errorMessage {
+          Text(error)
+            .foregroundStyle(.red)
+            .font(.footnote)
+        }
+
+        if authVM.isSignedIn {
+          NavigationLink("Go to Feed") {
+            FeedView(repo: FirebaseFeedRepo())
+          }
+
+          Button("Sign out") { authVM.signOut() }
+        } else {
+          Button("Technical login (anonymous)") { authVM.signInAnonymously() }
+        }
+
+        Spacer()
+      }
+      .padding()
+    }
+  }
+}
+

--- a/ios-native/VinctusNative/Sources/VinctusNativeApp.swift
+++ b/ios-native/VinctusNative/Sources/VinctusNativeApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+@main
+struct VinctusNativeApp: App {
+  init() {
+    FirebaseBootstrap.configureIfPossible()
+  }
+
+  var body: some Scene {
+    WindowGroup {
+      RootView()
+    }
+  }
+}
+

--- a/ios-native/VinctusNative/Tests/VinctusNativeTests.swift
+++ b/ios-native/VinctusNative/Tests/VinctusNativeTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+final class VinctusNativeTests: XCTestCase {
+  func testExample() {
+    XCTAssertTrue(true)
+  }
+}
+

--- a/ios-native/VinctusNative/VinctusNative.xcodeproj/project.pbxproj
+++ b/ios-native/VinctusNative/VinctusNative.xcodeproj/project.pbxproj
@@ -1,0 +1,677 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		02F41F5F99438C72D3C5C678 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9C1E82EF5046931A4836E1 /* AuthViewModel.swift */; };
+		1FD745B241CC985DA29E71E4 /* VinctusNativeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FBE102A72FA92BC6E78DE8 /* VinctusNativeTests.swift */; };
+		36C48C27188F959CE78BEBD1 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D8A1159261082593EAD650 /* RootView.swift */; };
+		56E2496AAB7FFC497E3F56C9 /* VinctusNativeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F530F8AF276B069F15B8D136 /* VinctusNativeApp.swift */; };
+		75912EA3A40807C55950D224 /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB7C98DFC400FC410886829 /* FeedViewModel.swift */; };
+		762D0E675177D06AAED7085C /* AuthRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E1E1F20B56DDF4BBA975CC /* AuthRepo.swift */; };
+		784110CF5F85F66F636C1955 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 64134F618816ABD24D123A39 /* FirebaseFirestore */; };
+		912F15F4581F1B37A3B1EDFB /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9704ADBE4A84D079E0A04D1C /* FeedView.swift */; };
+		9AA68A3394E43CD6F1560C3C /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969B5D6EE835BE96B822EF6E /* AppEnvironment.swift */; };
+		AAA82ED739E25ABB8C4BB215 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 1DFC0389A2A3A8827925595D /* FirebaseAuth */; };
+		CED347EFDC5DA085E7D07226 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 044E1F95CB1FA517D5923FCC /* FirebaseFunctions */; };
+		CEE76351CF20E4D879BB5F0F /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 215BFDEA7DFD70B3F014FF94 /* FirebaseStorage */; };
+		DD869C7A3714791D3731F73F /* FirebaseBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E21170D470DA7A3A12EDEF1 /* FirebaseBootstrap.swift */; };
+		FF33F35D2B8DCCFF45DA458C /* FeedRepo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B97C2ED97BA8671BCE68D4D2 /* FeedRepo.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		156FF5CA9BE3B17FD94A110A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C69454A017B116083EB8D97D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A7F1811097CE929423E42689;
+			remoteInfo = VinctusNative;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0B22A4DAC5EE2AAB608DB50D /* VinctusNativeTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = VinctusNativeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		19D8A1159261082593EAD650 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		32FBE102A72FA92BC6E78DE8 /* VinctusNativeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VinctusNativeTests.swift; sourceTree = "<group>"; };
+		5FB7C98DFC400FC410886829 /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
+		7E21170D470DA7A3A12EDEF1 /* FirebaseBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseBootstrap.swift; sourceTree = "<group>"; };
+		87E1E1F20B56DDF4BBA975CC /* AuthRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRepo.swift; sourceTree = "<group>"; };
+		95C5F3F30FF9C59DE0399CB7 /* VinctusNative.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = VinctusNative.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		969B5D6EE835BE96B822EF6E /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
+		9704ADBE4A84D079E0A04D1C /* FeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedView.swift; sourceTree = "<group>"; };
+		AA9C1E82EF5046931A4836E1 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
+		B97C2ED97BA8671BCE68D4D2 /* FeedRepo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRepo.swift; sourceTree = "<group>"; };
+		F530F8AF276B069F15B8D136 /* VinctusNativeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VinctusNativeApp.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		34D941AF8820AE5CFB1D01D3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AAA82ED739E25ABB8C4BB215 /* FirebaseAuth in Frameworks */,
+				784110CF5F85F66F636C1955 /* FirebaseFirestore in Frameworks */,
+				CED347EFDC5DA085E7D07226 /* FirebaseFunctions in Frameworks */,
+				CEE76351CF20E4D879BB5F0F /* FirebaseStorage in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0B0A07BF9FADF5E9621A1154 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				32FBE102A72FA92BC6E78DE8 /* VinctusNativeTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		542660F7CF2B2D3CE73C677E = {
+			isa = PBXGroup;
+			children = (
+				7E35AC2003C6EC59284F4C89 /* Sources */,
+				0B0A07BF9FADF5E9621A1154 /* Tests */,
+				F8A20CA52596A1539B16E3C8 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7E35AC2003C6EC59284F4C89 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				969B5D6EE835BE96B822EF6E /* AppEnvironment.swift */,
+				87E1E1F20B56DDF4BBA975CC /* AuthRepo.swift */,
+				AA9C1E82EF5046931A4836E1 /* AuthViewModel.swift */,
+				B97C2ED97BA8671BCE68D4D2 /* FeedRepo.swift */,
+				9704ADBE4A84D079E0A04D1C /* FeedView.swift */,
+				5FB7C98DFC400FC410886829 /* FeedViewModel.swift */,
+				7E21170D470DA7A3A12EDEF1 /* FirebaseBootstrap.swift */,
+				19D8A1159261082593EAD650 /* RootView.swift */,
+				F530F8AF276B069F15B8D136 /* VinctusNativeApp.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		F8A20CA52596A1539B16E3C8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				95C5F3F30FF9C59DE0399CB7 /* VinctusNative.app */,
+				0B22A4DAC5EE2AAB608DB50D /* VinctusNativeTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A7F1811097CE929423E42689 /* VinctusNative */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FB9C8A56AD53FC42DB8412CF /* Build configuration list for PBXNativeTarget "VinctusNative" */;
+			buildPhases = (
+				AEBC7287CC21701C90B3EA52 /* Sources */,
+				34D941AF8820AE5CFB1D01D3 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = VinctusNative;
+			packageProductDependencies = (
+				1DFC0389A2A3A8827925595D /* FirebaseAuth */,
+				64134F618816ABD24D123A39 /* FirebaseFirestore */,
+				044E1F95CB1FA517D5923FCC /* FirebaseFunctions */,
+				215BFDEA7DFD70B3F014FF94 /* FirebaseStorage */,
+			);
+			productName = VinctusNative;
+			productReference = 95C5F3F30FF9C59DE0399CB7 /* VinctusNative.app */;
+			productType = "com.apple.product-type.application";
+		};
+		BDF718743C4D295766AE4918 /* VinctusNativeTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 09D1BAAE3D9D4A0F995F5AA9 /* Build configuration list for PBXNativeTarget "VinctusNativeTests" */;
+			buildPhases = (
+				9DD42B1999B45636FC0E467F /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9C440DDB195F20022449D13D /* PBXTargetDependency */,
+			);
+			name = VinctusNativeTests;
+			packageProductDependencies = (
+			);
+			productName = VinctusNativeTests;
+			productReference = 0B22A4DAC5EE2AAB608DB50D /* VinctusNativeTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C69454A017B116083EB8D97D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+			};
+			buildConfigurationList = 1588BA2ACA136E9415FE1B71 /* Build configuration list for PBXProject "VinctusNative" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 542660F7CF2B2D3CE73C677E;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				A75E6CC52208AE511D979338 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
+			preferredProjectObjectVersion = 77;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A7F1811097CE929423E42689 /* VinctusNative */,
+				BDF718743C4D295766AE4918 /* VinctusNativeTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9DD42B1999B45636FC0E467F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1FD745B241CC985DA29E71E4 /* VinctusNativeTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AEBC7287CC21701C90B3EA52 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9AA68A3394E43CD6F1560C3C /* AppEnvironment.swift in Sources */,
+				762D0E675177D06AAED7085C /* AuthRepo.swift in Sources */,
+				02F41F5F99438C72D3C5C678 /* AuthViewModel.swift in Sources */,
+				FF33F35D2B8DCCFF45DA458C /* FeedRepo.swift in Sources */,
+				912F15F4581F1B37A3B1EDFB /* FeedView.swift in Sources */,
+				75912EA3A40807C55950D224 /* FeedViewModel.swift in Sources */,
+				DD869C7A3714791D3731F73F /* FirebaseBootstrap.swift in Sources */,
+				36C48C27188F959CE78BEBD1 /* RootView.swift in Sources */,
+				56E2496AAB7FFC497E3F56C9 /* VinctusNativeApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9C440DDB195F20022449D13D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A7F1811097CE929423E42689 /* VinctusNative */;
+			targetProxy = 156FF5CA9BE3B17FD94A110A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		060EC0993BFA69948424948D /* DebugStaging */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = Resources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.vinctus.native;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VINCTUS_ENV = staging;
+			};
+			name = DebugStaging;
+		};
+		09C1BA5B65F95764878C10C6 /* ReleaseProd */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 0.1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = ReleaseProd;
+		};
+		10D5258ADFD1AEDF2575C9B2 /* DebugStaging */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VinctusNative.app/VinctusNative";
+			};
+			name = DebugStaging;
+		};
+		2EE2713D8D25E8E6460134E5 /* DebugDev */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 0.1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = DebugDev;
+		};
+		6113BF7C0B6203DEBCD0EB62 /* ReleaseProd */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = Resources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.vinctus.native;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VINCTUS_ENV = prod;
+			};
+			name = ReleaseProd;
+		};
+		654D449FFDFD2E9B70C1704B /* ReleaseProd */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VinctusNative.app/VinctusNative";
+			};
+			name = ReleaseProd;
+		};
+		999A992BF58E617C9AF35306 /* DebugDev */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VinctusNative.app/VinctusNative";
+			};
+			name = DebugDev;
+		};
+		B14E61B5EF6BC2828D4B45A9 /* DebugProd */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VinctusNative.app/VinctusNative";
+			};
+			name = DebugProd;
+		};
+		B41F800B5221FBEE2F0A2A10 /* DebugDev */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = Resources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.vinctus.native;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VINCTUS_ENV = dev;
+			};
+			name = DebugDev;
+		};
+		BACC66141851E04B4E2DE9CC /* DebugProd */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 0.1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = DebugProd;
+		};
+		D5709947F74FEDEFDD80DE3F /* DebugProd */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = Resources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.vinctus.native;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VINCTUS_ENV = prod;
+			};
+			name = DebugProd;
+		};
+		EABC0E48E2D4D4C384072ACE /* DebugStaging */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 0.1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = DebugStaging;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		09D1BAAE3D9D4A0F995F5AA9 /* Build configuration list for PBXNativeTarget "VinctusNativeTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				999A992BF58E617C9AF35306 /* DebugDev */,
+				B14E61B5EF6BC2828D4B45A9 /* DebugProd */,
+				10D5258ADFD1AEDF2575C9B2 /* DebugStaging */,
+				654D449FFDFD2E9B70C1704B /* ReleaseProd */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = DebugDev;
+		};
+		1588BA2ACA136E9415FE1B71 /* Build configuration list for PBXProject "VinctusNative" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2EE2713D8D25E8E6460134E5 /* DebugDev */,
+				BACC66141851E04B4E2DE9CC /* DebugProd */,
+				EABC0E48E2D4D4C384072ACE /* DebugStaging */,
+				09C1BA5B65F95764878C10C6 /* ReleaseProd */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = DebugDev;
+		};
+		FB9C8A56AD53FC42DB8412CF /* Build configuration list for PBXNativeTarget "VinctusNative" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B41F800B5221FBEE2F0A2A10 /* DebugDev */,
+				D5709947F74FEDEFDD80DE3F /* DebugProd */,
+				060EC0993BFA69948424948D /* DebugStaging */,
+				6113BF7C0B6203DEBCD0EB62 /* ReleaseProd */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = DebugDev;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A75E6CC52208AE511D979338 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 11.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		044E1F95CB1FA517D5923FCC /* FirebaseFunctions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A75E6CC52208AE511D979338 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFunctions;
+		};
+		1DFC0389A2A3A8827925595D /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A75E6CC52208AE511D979338 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAuth;
+		};
+		215BFDEA7DFD70B3F014FF94 /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A75E6CC52208AE511D979338 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseStorage;
+		};
+		64134F618816ABD24D123A39 /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A75E6CC52208AE511D979338 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestore;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = C69454A017B116083EB8D97D /* Project object */;
+}

--- a/ios-native/VinctusNative/VinctusNative.xcodeproj/project.pbxproj
+++ b/ios-native/VinctusNative/VinctusNative.xcodeproj/project.pbxproj
@@ -227,7 +227,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.vinctus.native;
+				PRODUCT_BUNDLE_IDENTIFIER = app.vinctus.social;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VINCTUS_ENV = staging;
@@ -383,7 +383,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.vinctus.native;
+				PRODUCT_BUNDLE_IDENTIFIER = app.vinctus.social;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VINCTUS_ENV = prod;
@@ -446,7 +446,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.vinctus.native;
+				PRODUCT_BUNDLE_IDENTIFIER = app.vinctus.social;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VINCTUS_ENV = dev;
@@ -529,7 +529,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.vinctus.native;
+				PRODUCT_BUNDLE_IDENTIFIER = app.vinctus.social;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VINCTUS_ENV = prod;

--- a/ios-native/VinctusNative/VinctusNative.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios-native/VinctusNative/VinctusNative.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios-native/VinctusNative/VinctusNative.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios-native/VinctusNative/VinctusNative.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,132 @@
+{
+  "originHash" : "a1569f9895aa2be8e24832f98525d5da4eb90b5d158a82691c15b47eb72a13d7",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "c756a29784521063b6a1202907e2cc47f41b667c",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "c5ab62237f21cad094812719a1bbe29443407c5f",
+        "version" : "1.34.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios-native/VinctusNative/VinctusNative.xcodeproj/xcshareddata/xcschemes/VinctusNative-Dev.xcscheme
+++ b/ios-native/VinctusNative/VinctusNative.xcodeproj/xcshareddata/xcschemes/VinctusNative-Dev.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A7F1811097CE929423E42689"
+               BuildableName = "VinctusNative.app"
+               BlueprintName = "VinctusNative"
+               ReferencedContainer = "container:VinctusNative.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "DebugDev"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7F1811097CE929423E42689"
+            BuildableName = "VinctusNative.app"
+            BlueprintName = "VinctusNative"
+            ReferencedContainer = "container:VinctusNative.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BDF718743C4D295766AE4918"
+               BuildableName = "VinctusNativeTests.xctest"
+               BlueprintName = "VinctusNativeTests"
+               ReferencedContainer = "container:VinctusNative.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "DebugDev"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7F1811097CE929423E42689"
+            BuildableName = "VinctusNative.app"
+            BlueprintName = "VinctusNative"
+            ReferencedContainer = "container:VinctusNative.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "ReleaseProd"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7F1811097CE929423E42689"
+            BuildableName = "VinctusNative.app"
+            BlueprintName = "VinctusNative"
+            ReferencedContainer = "container:VinctusNative.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "DebugDev">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "ReleaseProd"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios-native/VinctusNative/VinctusNative.xcodeproj/xcshareddata/xcschemes/VinctusNative-Prod.xcscheme
+++ b/ios-native/VinctusNative/VinctusNative.xcodeproj/xcshareddata/xcschemes/VinctusNative-Prod.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A7F1811097CE929423E42689"
+               BuildableName = "VinctusNative.app"
+               BlueprintName = "VinctusNative"
+               ReferencedContainer = "container:VinctusNative.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "DebugProd"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7F1811097CE929423E42689"
+            BuildableName = "VinctusNative.app"
+            BlueprintName = "VinctusNative"
+            ReferencedContainer = "container:VinctusNative.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BDF718743C4D295766AE4918"
+               BuildableName = "VinctusNativeTests.xctest"
+               BlueprintName = "VinctusNativeTests"
+               ReferencedContainer = "container:VinctusNative.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "DebugProd"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7F1811097CE929423E42689"
+            BuildableName = "VinctusNative.app"
+            BlueprintName = "VinctusNative"
+            ReferencedContainer = "container:VinctusNative.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "ReleaseProd"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7F1811097CE929423E42689"
+            BuildableName = "VinctusNative.app"
+            BlueprintName = "VinctusNative"
+            ReferencedContainer = "container:VinctusNative.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "DebugDev">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "ReleaseProd"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios-native/VinctusNative/VinctusNative.xcodeproj/xcshareddata/xcschemes/VinctusNative-Staging.xcscheme
+++ b/ios-native/VinctusNative/VinctusNative.xcodeproj/xcshareddata/xcschemes/VinctusNative-Staging.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A7F1811097CE929423E42689"
+               BuildableName = "VinctusNative.app"
+               BlueprintName = "VinctusNative"
+               ReferencedContainer = "container:VinctusNative.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "DebugStaging"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7F1811097CE929423E42689"
+            BuildableName = "VinctusNative.app"
+            BlueprintName = "VinctusNative"
+            ReferencedContainer = "container:VinctusNative.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BDF718743C4D295766AE4918"
+               BuildableName = "VinctusNativeTests.xctest"
+               BlueprintName = "VinctusNativeTests"
+               ReferencedContainer = "container:VinctusNative.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "DebugStaging"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7F1811097CE929423E42689"
+            BuildableName = "VinctusNative.app"
+            BlueprintName = "VinctusNative"
+            ReferencedContainer = "container:VinctusNative.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "ReleaseProd"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A7F1811097CE929423E42689"
+            BuildableName = "VinctusNative.app"
+            BlueprintName = "VinctusNative"
+            ReferencedContainer = "container:VinctusNative.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "DebugDev">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "ReleaseProd"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios-native/VinctusNative/project.yml
+++ b/ios-native/VinctusNative/project.yml
@@ -33,7 +33,9 @@ targets:
       - path: Resources
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.vinctus.native
+        # Keep bundle id aligned with the existing Capacitor app so this can
+        # eventually ship as an update under the same App Store listing.
+        PRODUCT_BUNDLE_IDENTIFIER: app.vinctus.social
         INFOPLIST_FILE: Resources/Info.plist
       configs:
         DebugDev:

--- a/ios-native/VinctusNative/project.yml
+++ b/ios-native/VinctusNative/project.yml
@@ -1,0 +1,97 @@
+name: VinctusNative
+
+options:
+  deploymentTarget:
+    iOS: '17.0'
+  createIntermediateGroups: true
+
+configs:
+  DebugDev: debug
+  DebugStaging: debug
+  DebugProd: debug
+  ReleaseProd: release
+
+settings:
+  base:
+    CURRENT_PROJECT_VERSION: 1
+    MARKETING_VERSION: 0.1.0
+    SWIFT_VERSION: 5.0
+
+packages:
+  Firebase:
+    url: https://github.com/firebase/firebase-ios-sdk.git
+    from: 11.0.0
+
+targets:
+  VinctusNative:
+    type: application
+    platform: iOS
+    deploymentTarget: '17.0'
+    sources:
+      - path: Sources
+    resources:
+      - path: Resources
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.vinctus.native
+        INFOPLIST_FILE: Resources/Info.plist
+      configs:
+        DebugDev:
+          VINCTUS_ENV: dev
+        DebugStaging:
+          VINCTUS_ENV: staging
+        DebugProd:
+          VINCTUS_ENV: prod
+        ReleaseProd:
+          VINCTUS_ENV: prod
+    dependencies:
+      - package: Firebase
+        product: FirebaseAuth
+      - package: Firebase
+        product: FirebaseFirestore
+      - package: Firebase
+        product: FirebaseFunctions
+      - package: Firebase
+        product: FirebaseStorage
+
+  VinctusNativeTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: Tests
+    dependencies:
+      - target: VinctusNative
+
+schemes:
+  VinctusNative-Dev:
+    build:
+      targets:
+        VinctusNative: all
+    run:
+      config: DebugDev
+    test:
+      config: DebugDev
+      targets:
+        - VinctusNativeTests
+
+  VinctusNative-Staging:
+    build:
+      targets:
+        VinctusNative: all
+    run:
+      config: DebugStaging
+    test:
+      config: DebugStaging
+      targets:
+        - VinctusNativeTests
+
+  VinctusNative-Prod:
+    build:
+      targets:
+        VinctusNative: all
+    run:
+      config: DebugProd
+    test:
+      config: DebugProd
+      targets:
+        - VinctusNativeTests


### PR DESCRIPTION
Adds a SwiftUI native iOS scaffold for Semana 4.

- New folder: ios-native/VinctusNative
- XcodeGen project.yml with dev/staging/prod schemes via VINCTUS_ENV
- Firebase SDK via SPM (Auth/Firestore/Functions/Storage)
- FirebaseBootstrap: configures if env plist exists; app still runs without plist
- MVVM skeleton + AuthRepo/FeedRepo + simple RootView/FeedView

Local setup:
- Drop GoogleService-Info plists into ios-native/VinctusNative/Resources (ignored):
  - GoogleService-Info-Dev.plist
  - GoogleService-Info-Staging.plist
  - GoogleService-Info-Prod.plist