### PR TITLE
ios-native: don't crash if Firebase plist missing

### DIFF
--- a/ios-native/VinctusNative/Sources/AuthRepo.swift
+++ b/ios-native/VinctusNative/Sources/AuthRepo.swift
@@ -1,4 +1,5 @@
 import FirebaseAuth
+import FirebaseCore
 import Foundation
 
 protocol AuthRepo {
@@ -7,15 +8,31 @@ protocol AuthRepo {
   func signOut() throws
 }
 
+enum AuthRepoError: LocalizedError {
+  case firebaseNotConfigured
+
+  var errorDescription: String? {
+    switch self {
+    case .firebaseNotConfigured:
+      return "Firebase not configured. Add GoogleService-Info plist for this environment."
+    }
+  }
+}
+
 final class FirebaseAuthRepo: AuthRepo {
-  var currentUser: FirebaseAuth.User? { Auth.auth().currentUser }
+  var currentUser: FirebaseAuth.User? {
+    // FirebaseAuth will assert if Firebase isn't configured yet.
+    guard FirebaseApp.app() != nil else { return nil }
+    return Auth.auth().currentUser
+  }
 
   func signInAnonymously() async throws {
+    guard FirebaseApp.app() != nil else { throw AuthRepoError.firebaseNotConfigured }
     _ = try await Auth.auth().signInAnonymously()
   }
 
   func signOut() throws {
+    guard FirebaseApp.app() != nil else { throw AuthRepoError.firebaseNotConfigured }
     try Auth.auth().signOut()
   }
 }
-


### PR DESCRIPTION
Fixes a crash when running VinctusNative without a GoogleService-Info plist.

- Guard FirebaseAuth calls behind FirebaseApp.app() presence
- Return a user-friendly error when Firebase isn't configured yet